### PR TITLE
Allow PFTs in a CRS different from the other files

### DIFF
--- a/land_use_and_land_cover_change/config/main.yaml
+++ b/land_use_and_land_cover_change/config/main.yaml
@@ -1,7 +1,7 @@
 # Input Parameters
 
 # LUT configuration
-region : "NorthAmerica" # region name ("Germany", "Europe", "WestAfrica", "NorthAmerica", "Australasia")
+region : "Germany" # region name ("Germany", "Europe", "WestAfrica", "NorthAmerica", "Australasia")
 forward : False # forward or backward simulation
 backgrd : False # background  
 mcgrath : False # mcgrath
@@ -11,17 +11,17 @@ syear : 1950 # start year
 eyear : 2015 # end year
 mcgrath_eyear : 2010 # end year of mcgrath file (in case that its different from eyear)
 npfts : 16 # number of PFTs
-xsize : 1000 # xsize of the region
-ysize : 1000 # ysize of the region
+xsize : 95 # xsize of the region
+ysize : 89 # ysize of the region
 
 # LUH2 prepare data configuration
 prepare_luh2_data: True # prepare LUH2 data
 prepare_mcgrath: False # prepare mcgrath data
 remap : "bilinear" # remapping method ("bilinear", "con2")
 scenario : "historical" # scenario name ("historical", "historical_high", "historical_low", "rcp19", "rcp26", "rcp34", "rcp45","rcp60", "rcp70", "rcp85")
-grid : 0.011 # resolution in degrees
-coords : -83.5,-62.5,40.5,55.0  # region coordinates like "6,15.5,46.4,55.45" (lonmin,lonmax,latmin,latmax)
-coords_lc_in:  9.9,20.9,-2.9,8.2    # region coordinates in the CRS of the PFT file, if different from lat/lon
+grid : 0.1 # resolution in degrees
+coords : null        # region coordinates like "6,15.5,46.4,55.45" (lonmin,lonmax,latmin,latmax) (the CRS of the netCDFs) (except the PFTs)
+coords_lc_in: null  # coordinates of the same region in the CRS of the PFT file, if different 
 
 # Optional file paths
 path_file_trans: null # file path to transitions file

--- a/land_use_and_land_cover_change/config/main.yaml
+++ b/land_use_and_land_cover_change/config/main.yaml
@@ -1,7 +1,7 @@
 # Input Parameters
 
 # LUT configuration
-region : "Germany" # region name ("Germany", "Europe", "WestAfrica", "NorthAmerica", "Australasia")
+region : "NorthAmerica" # region name ("Germany", "Europe", "WestAfrica", "NorthAmerica", "Australasia")
 forward : False # forward or backward simulation
 backgrd : False # background  
 mcgrath : False # mcgrath
@@ -11,16 +11,17 @@ syear : 1950 # start year
 eyear : 2015 # end year
 mcgrath_eyear : 2010 # end year of mcgrath file (in case that its different from eyear)
 npfts : 16 # number of PFTs
-xsize : 95 # xsize of the region
-ysize : 89 # ysize of the region
+xsize : 1000 # xsize of the region
+ysize : 1000 # ysize of the region
 
 # LUH2 prepare data configuration
 prepare_luh2_data: True # prepare LUH2 data
 prepare_mcgrath: False # prepare mcgrath data
 remap : "bilinear" # remapping method ("bilinear", "con2")
 scenario : "historical" # scenario name ("historical", "historical_high", "historical_low", "rcp19", "rcp26", "rcp34", "rcp45","rcp60", "rcp70", "rcp85")
-grid : 0.1 # resolution in degrees
-coords : null # region coordinates like "6,15.5,46.4,55.45" (lonmin,lonmax,latmin,latmax)
+grid : 0.011 # resolution in degrees
+coords : -83.5,-62.5,40.5,55.0  # region coordinates like "6,15.5,46.4,55.45" (lonmin,lonmax,latmin,latmax)
+coords_lc_in:  9.9,20.9,-2.9,8.2    # region coordinates in the CRS of the PFT file, if different from lat/lon
 
 # Optional file paths
 path_file_trans: null # file path to transitions file

--- a/land_use_and_land_cover_change/config/validation.py
+++ b/land_use_and_land_cover_change/config/validation.py
@@ -47,6 +47,7 @@ schema = {
     "path_file_backcro" : {"type": "string", "nullable": True},
     "path_file_lsm" : {"type": "string", "nullable": True},
     "coords": {"type": "string", "nullable": True},
+    "coords_lc_in": {"type": "string", "nullable": True},
 }
 
 
@@ -68,13 +69,14 @@ def validate_config(config):
             raise ValueError("Mcgrath year (mcgrath_eyear) must be equal or smaller than ending year (eyear)")
         if config.mcgrath_eyear < config.syear:
             raise ValueError("Mcgrath year (mcgrath_eyear) must be equal or bigger than starting year (syear)")
-    if config.coords:
-        if len(config.coords.split(",")) != 4:
-            raise ValueError("Coordinates must given as 4 values (lonmin,lonmax,latmin,latmax) separated by commas")
-        try:
-            [float(config.coords.split(",")[i]) for i in range(4)]
-        except ValueError:
-            raise ValueError("Coordinates must be given as float values")
+    for crds in [config.coords, config.coords_lc_in]:
+        if crds:
+            if len(crds.split(",")) != 4:
+                raise ValueError("Coordinates must given as 4 values (lonmin,lonmax,latmin,latmax) separated by commas")
+            try:
+                [float(crds.split(",")[i]) for i in range(4)]
+            except ValueError:
+                raise ValueError("Coordinates must be given as float values")
 
 def validate_pfts_file(namelist, config):
     ds = xr.open_dataset(f"{namelist['F_LC_IN_REG'].replace('.nc','_tmp.nc')}")

--- a/land_use_and_land_cover_change/lut.py
+++ b/land_use_and_land_cover_change/lut.py
@@ -922,7 +922,7 @@ class LUT:
                     else:
                         cdo.add(input=f"-chname,{IRR[n]},irrig_frac -selvar,{IRR[n]} {path_region}/dummy.nc {path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc", output=f"{path_region}/dummy2.nc")
                         os.rename(f"{path_region}/dummy2.nc", f"{path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc")
-                    # os.remove(f"{path_region}/dummy.nc")
+                    os.remove(f"{path_region}/dummy.nc")
                 cdo.div(input=f"{path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc {path_region}/sum_crop_frac.nc", output=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}_2.nc")
                 cdo.setmisstoc("-999", input=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}_2.nc", output=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}.nc")
 
@@ -962,25 +962,6 @@ class LUT:
         """
         Prepare the PFTS data for the given grid
         """
-        # if self.grid == "reg025_Europe":
-        #     ext="NINT"
-        #     remap_com="invertlat"
-        #     cutting=''
-        # else:
-        #     if self.remap == "bilinear":
-        #         ext="BIL"
-        #         remap_com=f"remapbil"
-        #         if self.grid == "EUR-011":
-        #             cutting = "-selindexbox,2,434,2,434"
-        #         else:
-        #             cutting = ""
-        #     elif self.remap == "con2":
-        #         ext = "CON2"
-        #         remap_com = f"remapcon2"
-        #         if self.grid == 'EUR-011':
-        #             cutting = "-selindexbox,2,434,2,434"
-        #         else:
-        #             cutting = ''
         # prepare PFTS
         print_section_heading(f"Selecting variables for PFTS")
         input_file = self.namelist["F_LC_IN"]

--- a/land_use_and_land_cover_change/lut.py
+++ b/land_use_and_land_cover_change/lut.py
@@ -46,6 +46,10 @@ class LUT:
                 self.reg = coords["Germany"]
             elif self.region == 'WestAfrica':
                 self.reg = coords["WestAfrica"]
+        if self.coords_lc_in:
+            self.reg_lc = self.coords_lc_in
+        else:
+            self.reg_lc = self.reg
 
         self.pfts_grass = GRAPFTS[0:self.nr_grass]
         self.pfts_crops = CROPFTS[0:self.nr_crops]
@@ -918,7 +922,7 @@ class LUT:
                     else:
                         cdo.add(input=f"-chname,{IRR[n]},irrig_frac -selvar,{IRR[n]} {path_region}/dummy.nc {path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc", output=f"{path_region}/dummy2.nc")
                         os.rename(f"{path_region}/dummy2.nc", f"{path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc")
-                    os.remove(f"{path_region}/dummy.nc")
+                    # os.remove(f"{path_region}/dummy.nc")
                 cdo.div(input=f"{path_region}/sum_irri_frac_{self.syear}_{self.eyear}_{self.grid}.nc {path_region}/sum_crop_frac.nc", output=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}_2.nc")
                 cdo.setmisstoc("-999", input=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}_2.nc", output=f"{path_region}/{self.grid}/irrigation_{self.syear}_{self.eyear}_{self.grid}.nc")
 
@@ -958,34 +962,35 @@ class LUT:
         """
         Prepare the PFTS data for the given grid
         """
-        if self.grid == "reg025_Europe":
-            ext="NINT"
-            remap_com="invertlat"
-            cutting=''
-        else:
-            if self.remap == "bilinear":
-                ext="BIL"
-                remap_com=f"remapbil"
-                if self.grid == "EUR-011":
-                    cutting = "-selindexbox,2,434,2,434"
-                else:
-                    cutting = ""
-            elif self.remap == "con2":
-                ext = "CON2"
-                remap_com = f"remapcon2"
-                if self.grid == 'EUR-011':
-                    cutting = "-selindexbox,2,434,2,434"
-                else:
-                    cutting = ''
+        # if self.grid == "reg025_Europe":
+        #     ext="NINT"
+        #     remap_com="invertlat"
+        #     cutting=''
+        # else:
+        #     if self.remap == "bilinear":
+        #         ext="BIL"
+        #         remap_com=f"remapbil"
+        #         if self.grid == "EUR-011":
+        #             cutting = "-selindexbox,2,434,2,434"
+        #         else:
+        #             cutting = ""
+        #     elif self.remap == "con2":
+        #         ext = "CON2"
+        #         remap_com = f"remapcon2"
+        #         if self.grid == 'EUR-011':
+        #             cutting = "-selindexbox,2,434,2,434"
+        #         else:
+        #             cutting = ''
         # prepare PFTS
         print_section_heading(f"Selecting variables for PFTS")
         input_file = self.namelist["F_LC_IN"]
         ds = xr.open_dataset(input_file)
         var8 = True if "var801" in ds.variables else False
         if var8:
-            cdo.sellonlatbox(self.reg, input=f"-selvar,{vars_pfts} {input_file}", output=f"{self.namelist['F_LC_IN_REG'].replace('.nc','_tmp.nc')}")
+            cdo.sellonlatbox(self.reg_lc, input=f"-selvar,{vars_pfts} {input_file}", output=f"{self.namelist['F_LC_IN_REG'].replace('.nc','_tmp.nc')}")
         else:
-            cdo.sellonlatbox(self.reg, input=f"-selvar,{self.pfts_file_var} {input_file}", output=f"{self.namelist['F_LC_IN_REG'].replace('.nc','_tmp.nc')}")
+            cdo.sellonlatbox(self.reg_lc, input=f"-selvar,{self.pfts_file_var} {input_file}", output=f"{self.namelist['F_LC_IN_REG'].replace('.nc','_tmp.nc')}")
+
 
     def func_prepare_pfts_file(self):
         """


### PR DESCRIPTION
Hi!

This PR adds a config entry to specify the region in the coordinates of the PFT file when those are different from the ones in the other files. I think that all files use lat/lon coordinates, but my PFT file is on a Rotated Pole coordinate system. By splitting the two coordinate sets, the subsetting of the PFT file works.

I also took the liberty to remove an unused paragraph in `func_prepare_pfts_tmp_file`.